### PR TITLE
as per issue #378, converted the node registry to be a single global …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,25 @@ language: python
 sudo: required
 python:
   - "2.7"
-  - "3.4"
-  - "3.5"
+#  - "3.4"
+#  - "3.5"
   - "3.6"
 env:
-  - NEO4J_VERSION="3.0.10"
-  - NEO4J_VERSION="3.1.7"
-  - NEO4J_VERSION="3.2.9"
-  - NEO4J_VERSION="3.3.3"
+  #- NEO4J_VERSION="3.0.10"  # unsupported by neo4j.com (DEC18)
+  #- NEO4J_VERSION="3.1.7"   # unsupported by neo4j.com (DEC18)
+  #- NEO4J_VERSION="3.2.13"
+  - NEO4J_VERSION="3.3.9"
+  - NEO4J_VERSION="3.4.10"
+  - NEO4J_VERSION="3.5.0"
 install:
   - sudo apt-get update && sudo apt-get install oracle-java8-installer
   - curl -L http://dist.neo4j.org/neo4j-community-$NEO4J_VERSION-unix.tar.gz | tar xz
+  - pip install tox-travis
 before_script:
   - JAVA_HOME=/usr/lib/jvm/java-8-oracle neo4j-community-$NEO4J_VERSION/bin/neo4j start
   - sleep 10
-script: "python setup.py test"
+script:
+  - tox
+notifications:
+  email: false
+

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+'neo4j-driver' = ">=1.5.2, <1.7.0"
+pytz = ">=2016.10"
+
+[dev-packages]
+tox = "*"
+
+[requires]
+python_version = "3.6"

--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,21 @@ An Object Graph Mapper (OGM) for the neo4j_ graph database, built on the awesome
 .. _neo4j: https://neo4j.com/
 .. _neo4j_driver: https://github.com/neo4j/neo4j-python-driver
 
+.. image:: https://img.shields.io/pypi/v/neomodel.svg
+    :target: https://pypi.python.org/pypi/neomodel
+    :alt: Version
+
+.. image:: https://img.shields.io/badge/neo4j-3.0%20%7C%203.1%20%7C%203.2%20%7C%203.3%20%7C%203.4%20%7C%203.5-blue.svg
+    :target: https://neo4j.com
+    :alt: Supported Neo4j versions
+
+.. image:: https://img.shields.io/pypi/pyversions/neomodel.svg
+    :target: https://pypi.python.org/pypi/neomodel
+    :alt: Supported Python Versions
+
 .. image:: https://secure.travis-ci.org/neo4j-contrib/neomodel.png
     :target: https://secure.travis-ci.org/neo4j-contrib/neomodel/
+    :alt: Build Status
 
 .. image:: https://readthedocs.org/projects/neomodel/badge/?version=latest
     :alt: Documentation Status
@@ -34,7 +47,7 @@ Requirements
 ============
 
 - Python 2.7, 3.4+
-- neo4j 3.0, 3.1, 3.2, 3.3
+- neo4j 3.0, 3.1, 3.2, 3.3, 3.4, 3.5
 
 Installation
 ============
@@ -50,13 +63,13 @@ To install from github::
 Upgrading 2.x to 3.x
 ====================
 
- * Now utilises neo4j_driver as the backend which uses bolt so neo4j 3 is required
- * Connection now set through config.DATABASE_URL (see getting started docs)
- * The deprecated category() method on StructuredNode has been removed
- * The deprecated index property on StructuredNode has been removed
- * The streaming=True flag is now irrelevant with bolt and produces a deprecation warning
+ * Now utilises `neo4j_driver` as the backend which uses bolt so neo4j 3+ is required
+ * Connection now set through `config.DATABASE_URL` (see getting started docs)
+ * The deprecated category() method on `StructuredNode` has been removed
+ * The deprecated index property on `StructuredNode` has been removed
+ * The `streaming=True` flag is now irrelevant with bolt and produces a deprecation warning
  * Batch operations must now be wrapped in a transaction in order to be atomic
- * Indexing NodeSets returns a single node now as opposed to a list
+ * Indexing `NodeSets` returns a single node now as opposed to a list
 
 Contributing
 ============
@@ -79,7 +92,7 @@ Setup a virtual environment, install neomodel for development and run the test s
 
 If your running a neo4j database for the first time the test suite will set the password to 'test'.
 
-If you have ``docker-compose`` installed, you can run the test suite against all supported Python
+If you have `docker-compose` installed, you can run the test suite against all supported Python
 interpreters and neo4j versions::
 
     # in the project's root folder:

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -6,7 +6,7 @@ from neomodel import config
 from neomodel.exceptions import DoesNotExist
 from neomodel.hooks import hooks
 from neomodel.properties import Property, PropertyManager
-from neomodel.util import Database, classproperty, _UnsavedNode, _get_node_properties
+from neomodel.util import Database, classproperty, _UnsavedNode, _get_node_properties, get_node_class_registry
 
 db = Database()
 
@@ -171,8 +171,10 @@ class NodeMeta(type):
 
             if config.AUTO_INSTALL_LABELS:
                 install_labels(cls)
-            db._NODE_CLASS_REGISTRY[frozenset(cls.inherited_labels())] = cls
-            
+
+            # store in the noce class regustry
+            get_node_class_registry().update({frozenset(cls.inherited_labels()): cls})
+
         return cls
 
 
@@ -255,7 +257,8 @@ class StructuredNode(NodeBase):
         query_params = dict(merge_params=merge_params)
         n_merge = "n:{} {{{}}}".format(
             ":".join(cls.inherited_labels()),
-            ", ".join("{0}: params.create.{0}".format(getattr(cls, p).db_property or p) for p in cls.__required_properties__))
+            ", ".join(
+                "{0}: params.create.{0}".format(getattr(cls, p).db_property or p) for p in cls.__required_properties__))
         if relationship is None:
             # create "simple" unwind query
             query = "UNWIND {{merge_params}} as params\n MERGE ({})\n ".format(n_merge)
@@ -292,7 +295,7 @@ class StructuredNode(NodeBase):
     @classmethod
     def category(cls):
         raise NotImplementedError("Category was deprecated and has now been removed, "
-            "the functionality is now achieved using the {}.nodes attribute".format(cls.__name__))
+                                  "the functionality is now achieved using the {}.nodes attribute".format(cls.__name__))
 
     @classmethod
     def create(cls, *props, **kwargs):
@@ -494,7 +497,7 @@ class StructuredNode(NodeBase):
         self._pre_action_check('refresh')
         if hasattr(self, 'id'):
             request = self.cypher("MATCH (n) WHERE id(n)={self}"
-                                            " RETURN n")[0]
+                                  " RETURN n")[0]
             if not request or not request[0]:
                 raise self.__class__.DoesNotExist("Can't refresh non existent node")
             node = self.inflate(request[0][0])

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -8,7 +8,7 @@ from threading import local
 from neo4j.v1 import GraphDatabase, basic_auth, CypherError, SessionError, Node
 
 from . import config
-from .exceptions import UniqueProperty, ConstraintValidationFailed,  ModelDefinitionMismatch
+from .exceptions import UniqueProperty, ConstraintValidationFailed, ModelDefinitionMismatch
 
 if sys.version_info >= (3, 0):
     from urllib.parse import urlparse
@@ -42,11 +42,20 @@ def clear_neo4j_database(db):
     db.cypher_query("MATCH (a) DETACH DELETE a")
 
 
+__NODE_CLASS_REGISTRY = None
+
+def get_node_class_registry():
+    global __NODE_CLASS_REGISTRY
+    if not __NODE_CLASS_REGISTRY:
+        __NODE_CLASS_REGISTRY = {}
+    return __NODE_CLASS_REGISTRY
+
+
 class Database(local):
     """
     A singleton object via which all operations from neomodel to the Neo4j backend are handled with.
     """
-    
+
     def __init__(self):
         """
         """
@@ -59,7 +68,7 @@ class Database(local):
         # node in the resultset.
         # _NODE_CLASS_REGISTRY is populated automatically by the constructor
         # of the NodeMeta type.
-        self._NODE_CLASS_REGISTRY = {}
+        # self._NODE_CLASS_REGISTRY = get_node_class_registry()
 
     def set_connection(self, url):
         """
@@ -92,10 +101,10 @@ class Database(local):
     @property
     def write_transaction(self):
         return TransactionProxy(self, access_mode="WRITE")
-        
+
     @property
     def read_transaction(self):
-        return TransactionProxy(self, access_mode="READ")        
+        return TransactionProxy(self, access_mode="READ")
 
     @ensure_connection
     def begin(self, access_mode=None):
@@ -131,45 +140,44 @@ class Database(local):
         The function operates recursively in order to be able to resolve Nodes
         within nested list structures. Not meant to be called directly,
         used primarily by cypher_query.
-        
+
         :param result_list: A list of results as returned by cypher_query.
         :type list:
-        
+
         :return: A list of instantiated objects.
         """
-        
+
         # Object resolution occurs in-place
         for a_result_item in enumerate(result_list):
-            for a_result_attribute in enumerate(a_result_item[1]):                    
+            for a_result_attribute in enumerate(a_result_item[1]):
                 try:
-                    # Primitive types should remain primitive types, 
+                    # Primitive types should remain primitive types,
                     #  Nodes to be resolved to native objects
                     resolved_object = a_result_attribute[1]
-                    
+
                     if type(a_result_attribute[1]) is Node:
-                        resolved_object = self._NODE_CLASS_REGISTRY[frozenset(a_result_attribute[1].labels)].inflate(
+                        resolved_object = get_node_class_registry().get(frozenset(a_result_attribute[1].labels)).inflate(
                             a_result_attribute[1])
-                        
+
                     if type(a_result_attribute[1]) is list:
-                        resolved_object = self._object_resolution([a_result_attribute[1]])                    
-                    
+                        resolved_object = self._object_resolution([a_result_attribute[1]])
+
                     result_list[a_result_item[0]][a_result_attribute[0]] = resolved_object
-                    
+
                 except KeyError:
-                    # Not being able to match the label set of a node with a known object results 
-                    # in a KeyError in the internal dictionary used for resolution. If it is impossible 
+                    # Not being able to match the label set of a node with a known object results
+                    # in a KeyError in the internal dictionary used for resolution. If it is impossible
                     # to match, then raise an exception with more details about the error.
-                    raise ModelDefinitionMismatch(a_result_attribute[1], self._NODE_CLASS_REGISTRY)
-                    
+                    raise ModelDefinitionMismatch(a_result_attribute[1], get_node_class_registry())
+
         return result_list
 
-        
-        
     @ensure_connection
-    def cypher_query(self, query, params=None, handle_unique=True, retry_on_session_expire=False, resolve_objects=False):
+    def cypher_query(self, query, params=None, handle_unique=True, retry_on_session_expire=False,
+                     resolve_objects=False):
         """
         Runs a query on the database and returns a list of results and their headers.
-        
+
         :param query: A CYPHER query
         :type: str
         :param params: Dictionary of parameters
@@ -177,11 +185,11 @@ class Database(local):
         :param handle_unique: Whether or not to raise UniqueProperty exception on Cypher's ConstraintValidation errors
         :type: bool
         :param retry_on_session_expire: Whether or not to attempt the same query again if the transaction has expired
-        :type: bool        
+        :type: bool
         :param resolve_objects: Whether to attempt to resolve the returned nodes to data model objects automatically
         :type: bool
         """
-        
+
         if self._pid != os.getpid():
             self.set_connection(self.url)
 
@@ -196,11 +204,11 @@ class Database(local):
             response = session.run(query, params)
             results, meta = [list(r.values()) for r in response], response.keys()
             end = time.clock()
-            
+
             if resolve_objects:
                 # Do any automatic resolution required
                 results = self._object_resolution(results)
-                
+
         except CypherError as ce:
             if ce.code == u'Neo.ClientError.Schema.ConstraintValidationFailed':
                 if 'already exists with label' in ce.message and handle_unique:
@@ -226,8 +234,8 @@ class Database(local):
             logger.debug("query: " + query + "\nparams: " + repr(params) + "\ntook: %.2gs\n" % (end - start))
 
         return results, meta
-        
-        
+
+
 class TransactionProxy(object):
     def __init__(self, db, access_mode=None):
         self.db = db
@@ -245,10 +253,10 @@ class TransactionProxy(object):
         if exc_type is CypherError:
             if exc_value.code == u'Neo.ClientError.Schema.ConstraintValidationFailed':
                 raise UniqueProperty(exc_value.message)
-                
+
         if not exc_value:
-            self.db.commit()                            
-            
+            self.db.commit()
+
     def __call__(self, func):
         def wrapper(*args, **kwargs):
             with self:

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ addopts = test --strict
 
 [aliases]
 test = pytest
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='neomodel',
-    version='3.3.0',
+    version='3.3.0+ncrsingleton',
     description='An object mapper for the neo4j graph database.',
     long_description=open('README.rst').read(),
     author='Robin Edwards',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,38 +10,38 @@ from neo4j.v1 import CypherError
 def pytest_addoption(parser):
     """
     Adds the command line option --resetdb.
-    
+
     :param parser: The parser object. Please see <https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_addoption>`_
     :type Parser object: For more information please see <https://docs.pytest.org/en/latest/reference.html#_pytest.config.Parser>`_
     """
     parser.addoption("--resetdb", action="store_true", help = "Ensures that the database is clear prior to running tests for neomodel", default=False)
-    
+
 def pytest_sessionstart(session):
     """
     Provides initial connection to the database and sets up the rest of the test suite
-    
+
     :param session: The session object. Please see <https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_sessionstart>`_
     :type Session object: For more information please see <https://docs.pytest.org/en/latest/reference.html#session>`_
     """
-    
+
     warnings.simplefilter('default')
-    
+
     config.DATABASE_URL = os.environ.get('NEO4J_BOLT_URL', 'bolt://neo4j:neo4j@localhost:7687')
     config.AUTO_INSTALL_LABELS = True
-    
+
     try:
         # Clear the database if required
         database_is_populated, _ = db.cypher_query("MATCH (a) return count(a)>0 as database_is_populated")
         if database_is_populated[0][0] and not session.config.getoption("resetdb"):
             raise SystemError("Please note: The database seems to be populated.\n\tEither delete all nodes and edges manually, or set the --resetdb parameter when calling pytest\n\n\tpytest --resetdb.")
         else:
-            clear_neo4j_database(db)        
+            clear_neo4j_database(db)
     except CypherError as ce:
         # Handle instance without password being changed
         if 'The credentials you provided were valid, but must be changed before you can use this instance' in str(ce):
             warnings.warn("New database with no password set, setting password to 'test'")
             change_neo4j_password(db, 'test')
-            db.set_connection('bolt://neo4j:test@localhost:7687')            
+            db.set_connection('bolt://neo4j:test@localhost:7687')
             warnings.warn("Please 'export NEO4J_BOLT_URL=bolt://neo4j:test@localhost:7687' for subsequent test runs")
         else:
             raise ce

--- a/test/test_issue283.py
+++ b/test/test_issue283.py
@@ -5,8 +5,8 @@ The issue is outlined here: https://github.com/neo4j-contrib/neomodel/issues/283
 More information about the same issue at:
 https://github.com/aanastasiou/neomodelInheritanceTest
 
-The following example uses a recursive relationship for economy, but the 
-idea remains the same: "Instantiate the correct type of node at the end of 
+The following example uses a recursive relationship for economy, but the
+idea remains the same: "Instantiate the correct type of node at the end of
 a relationship as specified by the model"
 """
 
@@ -16,6 +16,8 @@ import datetime
 import pytest
 import random
 
+from neomodel import get_node_class_registry
+
 try:
     basestring
 except NameError:
@@ -24,13 +26,13 @@ except NameError:
 # Set up a very simple model for the tests
 class PersonalRelationship(neomodel.StructuredRel):
     """
-    A very simple relationship between two basePersons that simply records 
+    A very simple relationship between two basePersons that simply records
     the date at which an acquaintance was established.
-    This relationship should be carried over to anything that inherits from 
+    This relationship should be carried over to anything that inherits from
     basePerson without any further effort.
     """
     on_date = neomodel.DateProperty(default_now = True)
-    
+
 class BasePerson(neomodel.StructuredNode):
     """
     Base class for defining some basic sort of an actor.
@@ -38,40 +40,40 @@ class BasePerson(neomodel.StructuredNode):
     name = neomodel.StringProperty(required = True, unique_index = True)
     friends_with = neomodel.RelationshipTo("BasePerson", "FRIENDS_WITH",
                                            model = PersonalRelationship)
-    
+
 class TechnicalPerson(BasePerson):
     """
     A Technical person specialises BasePerson by adding their expertise.
     """
     expertise = neomodel.StringProperty(required = True)
-    
+
 class PilotPerson(BasePerson):
     """
     A pilot person specialises BasePerson by adding the type of airplane they
     can operate.
     """
     airplane = neomodel.StringProperty(required = True)
-    
+
 class BaseOtherPerson(neomodel.StructuredNode):
     """
     An obviously "wrong" class of actor to befriend BasePersons with.
     """
     car_color = neomodel.StringProperty(required = True)
-    
+
 class SomePerson(BaseOtherPerson):
     """
     Concrete class that simply derives from BaseOtherPerson.
     """
-    pass  
+    pass
 
 
 # Test cases
 def test_automatic_object_resolution():
     """
-    Node objects at the end of relationships are instantiated to their 
+    Node objects at the end of relationships are instantiated to their
     corresponding Python object.
     """
-        
+
     # Create a few entities
     A = TechnicalPerson.get_or_create({"name":"Grumpy", "expertise":"Grumpiness"})[0]
     B = TechnicalPerson.get_or_create({"name":"Happy", "expertise":"Unicorns"})[0]
@@ -84,25 +86,25 @@ def test_automatic_object_resolution():
 
     # If A is friends with B, then A's friends_with objects should be
     # TechnicalPerson (!NOT basePerson!)
-    assert type(A.friends_with[0]) is TechnicalPerson    
-    
+    assert type(A.friends_with[0]) is TechnicalPerson
+
     A.delete()
     B.delete()
     C.delete()
-    
+
 def test_recursive_automatic_object_resolution():
     """
     Node objects are instantiated to native Python objects, both at the top
     level of returned results and in the case where they are returned within
     lists.
     """
-        
+
     # Create a few entities
     A = TechnicalPerson.get_or_create({"name":"Grumpier", "expertise":"Grumpiness"})[0]
     B = TechnicalPerson.get_or_create({"name":"Happier", "expertise":"Grumpiness"})[0]
     C = TechnicalPerson.get_or_create({"name":"Sleepier", "expertise":"Pillows"})[0]
     D = TechnicalPerson.get_or_create({"name":"Sneezier", "expertise":"Pillows"})[0]
-    
+
     # Retrieve mixed results, both at the top level and nested
     L, _ = neomodel.db.cypher_query("MATCH (a:TechnicalPerson) "
                                     "WHERE a.expertise='Grumpiness' "
@@ -112,81 +114,81 @@ def test_recursive_automatic_object_resolution():
                                     "WITH Alpha, collect(b) as Beta "
                                     "RETURN [Alpha, [Beta, [Beta, ['Banana', "
                                     "Alpha]]]]", resolve_objects = True)
-    
+
     # Assert that a Node returned deep in a nested list structure is of the
     # correct type
     assert type(L[0][0][0][1][0][0][0][0]) is TechnicalPerson
     # Assert that primitive data types remain primitive data types
     assert issubclass(type(L[0][0][0][1][0][1][0][1][0][0]), basestring)
-    
+
     A.delete()
     B.delete()
     C.delete()
     D.delete()
-    
-    
-def test_validation_with_inheritance_from_db():    
+
+
+def test_validation_with_inheritance_from_db():
     """
     Objects descending from the specified class of a relationship's end-node are
     also perfectly valid to appear as end-node values too
     """
-    
+
     #Create a few entities
     # Technical Persons
     A = TechnicalPerson.get_or_create({"name":"Grumpy", "expertise":"Grumpiness"})[0]
     B = TechnicalPerson.get_or_create({"name":"Happy", "expertise":"Unicorns"})[0]
     C = TechnicalPerson.get_or_create({"name":"Sleepy", "expertise":"Pillows"})[0]
-    
+
     # Pilot Persons
     D = PilotPerson.get_or_create({"name":"Porco Rosso", "airplane":"Savoia-Marchetti"})[0]
     E = PilotPerson.get_or_create({"name":"Jack Dalton", "airplane":"Beechcraft Model 18"})[0]
-    
+
     # TechnicalPersons can befriend PilotPersons and vice-versa and that's fine
-    
+
     # TechnicalPersons befriend Technical Persons
     A.friends_with.connect(B)
     B.friends_with.connect(C)
     C.friends_with.connect(A)
-    
+
     # Pilot Persons befriend Pilot Persons
     D.friends_with.connect(E)
-    
+
     # Technical Persons befriend Pilot Persons
     A.friends_with.connect(D)
     E.friends_with.connect(C)
-    
-    # This now means that friends_with of a TechnicalPerson can 
+
+    # This now means that friends_with of a TechnicalPerson can
     # either be TechnicalPerson or Pilot Person (!NOT basePerson!)
-    
+
     assert (type(A.friends_with[0]) is TechnicalPerson) or (type(A.friends_with[0]) is PilotPerson)
     assert (type(A.friends_with[1]) is TechnicalPerson) or (type(A.friends_with[1]) is PilotPerson)
     assert type(D.friends_with[0]) is PilotPerson
-    
+
     A.delete()
     B.delete()
     C.delete()
     D.delete()
     E.delete()
-    
-        
-def test_validation_enforcement_to_db():        
+
+
+def test_validation_enforcement_to_db():
     """
     If a connection between wrong types is attempted, raise an exception
     """
-    
+
     #Create a few entities
     # Technical Persons
     A = TechnicalPerson.get_or_create({"name":"Grumpy", "expertise":"Grumpiness"})[0]
     B = TechnicalPerson.get_or_create({"name":"Happy", "expertise":"Unicorns"})[0]
     C = TechnicalPerson.get_or_create({"name":"Sleepy", "expertise":"Pillows"})[0]
-    
+
     # Pilot Persons
     D = PilotPerson.get_or_create({"name":"Porco Rosso", "airplane":"Savoia-Marchetti"})[0]
     E = PilotPerson.get_or_create({"name":"Jack Dalton", "airplane":"Beechcraft Model 18"})[0]
-    
-    #Some Person    
+
+    #Some Person
     F = SomePerson(car_color = "Blue").save()
-    
+
     # TechnicalPersons can befriend PilotPersons and vice-versa and that's fine
     A.friends_with.connect(B)
     B.friends_with.connect(C)
@@ -194,48 +196,48 @@ def test_validation_enforcement_to_db():
     D.friends_with.connect(E)
     A.friends_with.connect(D)
     E.friends_with.connect(C)
-    
+
     # Trying to befriend a Technical Person with Some Person should raise an
     # exception
     with pytest.raises(ValueError):
         A.friends_with.connect(F)
-    
+
     A.delete()
     B.delete()
     C.delete()
     D.delete()
     E.delete()
     F.delete()
-        
+
 
 def test_failed_object_resolution():
     """
     A Neo4j driver node FROM the database contains labels that are unaware to
-    neomodel's Database class. This condition raises ClassDefinitionNotFound 
+    neomodel's Database class. This condition raises ClassDefinitionNotFound
     exception.
     """
-    
+
     class RandomPerson(BasePerson):
         randomness = neomodel.FloatProperty(default = random.random)
-    
+
     # A Technical Person...
     A = TechnicalPerson.get_or_create({"name":"Grumpy", "expertise":"Grumpiness"})[0]
-    
+
     # A Random Person...
     B = RandomPerson.get_or_create({"name":"Mad Hatter"})[0]
-    
+
     A.friends_with.connect(B)
-    
+
     # Simulate the condition where the definition of class RandomPerson is not
     # known yet.
-    del neomodel.db._NODE_CLASS_REGISTRY[frozenset(["RandomPerson","BasePerson"])]        
-    
+    del get_node_class_registry()[frozenset(["RandomPerson","BasePerson"])]
+
     # Now try to instantiate a RandomPerson
     A = TechnicalPerson.get_or_create({"name":"Grumpy", "expertise":"Grumpiness"})[0]
-    with pytest.raises(neomodel.exceptions.ModelDefinitionMismatch):        
+    with pytest.raises(neomodel.exceptions.ModelDefinitionMismatch):
         for some_friend in A.friends_with:
             print(some_friend.name)
-            
+
     A.delete()
     B.delete()
 
@@ -245,30 +247,30 @@ def test_node_label_mismatch():
     A Neo4j driver node FROM the database contains a superset of the known
     labels.
     """
-    
+
     class SuperTechnicalPerson(TechnicalPerson):
         superness = neomodel.FloatProperty(default=1.0)
-        
+
     class UltraTechnicalPerson(SuperTechnicalPerson):
-        ultraness = neomodel.FloatProperty(default=3.1415928)        
-        
+        ultraness = neomodel.FloatProperty(default=3.1415928)
+
     # Create a TechnicalPerson...
     A = TechnicalPerson.get_or_create({"name":"Grumpy", "expertise":"Grumpiness"})[0]
     # ...that is connected to an UltraTechnicalPerson
     F = UltraTechnicalPerson(name = "Chewbaka", expertise="Aarrr wgh ggwaaah").save()
     A.friends_with.connect(F)
-    
-    
+
+
     # Forget about the UltraTechnicalPerson
-    del neomodel.db._NODE_CLASS_REGISTRY[frozenset(["UltraTechnicalPerson",
+    del get_node_class_registry()[frozenset(["UltraTechnicalPerson",
                                                     "SuperTechnicalPerson",
                                                     "TechnicalPerson",
                                                     "BasePerson"])]
-    
-    # Recall a TechnicalPerson and enumerate its friends. 
+
+    # Recall a TechnicalPerson and enumerate its friends.
     # One of them is UltraTechnicalPerson which would be returned as a valid
     # node to a friends_with query but is currently unknown to the node class registry.
     A = TechnicalPerson.get_or_create({"name":"Grumpy", "expertise":"Grumpiness"})[0]
-    with pytest.raises(neomodel.exceptions.ModelDefinitionMismatch):            
+    with pytest.raises(neomodel.exceptions.ModelDefinitionMismatch):
         for some_friend in A.friends_with:
             print(some_friend.name)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,80 @@
+# this file is *not* meant to cover or endorse the use of tox or pytest or
+# testing in general,
+#
+#  It's meant to show the use of:
+#
+#  - check-manifest
+#     confirm items checked into vcs are in your sdist
+#  - python setup.py check (using the readme_renderer extension)
+#     confirms your long_description will render correctly on pypi
+#
+#  and also to help confirm pull requests to this project.
+
+[tox]
+envlist = py27, py36, dist_and_docs
+
+[travis]
+python =
+    3.6: py36, dist_and_docs
+
+[testenv]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH NEO4J_BOLT_URL
+deps =
+    pytest
+
+commands =
+    pytest --resetdb
+
+basepython =
+    py27: python2.7
+    py34: python3.4
+    py35: python3.5
+    py36: python3.6
+    py37: python3.7
+    pypy: pypy
+    pypy3: pypy3
+    py2: python2.7
+    py3: python3.6
+
+[testenv:py36]
+deps =
+    pytest
+    coverage
+    coveralls
+
+commands =
+    pytest --resetdb
+    #  coverage run --source=neomodel setup.py test --resetdb
+    # - coveralls
+
+[testenv:dist_and_docs]
+basepython = python3.6
+deps =
+    check-manifest
+    flake8
+    pydocstyle
+    docutils
+commands =
+    flake8 pykechain
+    pydocstyle pykechain
+    python setup.py check -m -r -s
+
+
+# test settings
+[flake8]
+max-line-length = 120
+statistics = True
+
+[pydocstyle]
+ignore = D100,D105,D203,D212,D213
+
+#from: http://www.pydocstyle.org/en/latest/error_codes.html
+#D100	Missing docstring in public module
+#D105	Missing docstring in magic method
+#D203	1 blank line required before class docstring
+#D212	Multi-line docstring summary should start at the first line
+#D213	Multi-line docstring summary should start at the second line
+
+[pytest]
+addopts = -l --color=yes -v
+testpaths = test


### PR DESCRIPTION
…dictionary.

* most test pass, except those where direct altering of the node registry is done
  * [test_failed_object_resolution](test/test_issue283.py#L213)
  * [test_nodel_label_mismatch](test/test_issue283.py)